### PR TITLE
feat: 기본 Entity 및 DB 설정 (Author, Book)

### DIFF
--- a/src/main/java/com/hwk9407/bookmanagementassignment/domain/author/Author.java
+++ b/src/main/java/com/hwk9407/bookmanagementassignment/domain/author/Author.java
@@ -1,0 +1,27 @@
+package com.hwk9407.bookmanagementassignment.domain.author;
+
+import jakarta.persistence.*;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor
+public class Author {
+
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private String name;
+
+    @Column(nullable = false, unique = true)
+    private String email;
+
+    @Builder
+    public Author(String name, String email) {
+        this.name = name;
+        this.email = email;
+    }
+}

--- a/src/main/java/com/hwk9407/bookmanagementassignment/domain/author/AuthorRepository.java
+++ b/src/main/java/com/hwk9407/bookmanagementassignment/domain/author/AuthorRepository.java
@@ -1,0 +1,6 @@
+package com.hwk9407.bookmanagementassignment.domain.author;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface AuthorRepository extends JpaRepository<Author, Long> {
+}

--- a/src/main/java/com/hwk9407/bookmanagementassignment/domain/book/Book.java
+++ b/src/main/java/com/hwk9407/bookmanagementassignment/domain/book/Book.java
@@ -1,0 +1,37 @@
+package com.hwk9407.bookmanagementassignment.domain.book;
+
+import com.hwk9407.bookmanagementassignment.domain.author.Author;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Book {
+
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private String title;
+
+    @Column
+    private String description;
+
+    @Column(nullable = false, unique = true)
+    private String isbn;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "author_id", nullable = false)
+    private Author author;
+
+    @Builder
+    public Book(String title, String description, String isbn) {
+        this.title = title;
+        this.description = description;
+        this.isbn = isbn;
+    }
+}

--- a/src/main/java/com/hwk9407/bookmanagementassignment/domain/book/BookRepository.java
+++ b/src/main/java/com/hwk9407/bookmanagementassignment/domain/book/BookRepository.java
@@ -1,0 +1,6 @@
+package com.hwk9407.bookmanagementassignment.domain.book;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface BookRepository extends JpaRepository<Book, Long> {
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,1 +1,0 @@
-spring.application.name=book-management-assignment

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,0 +1,20 @@
+spring:
+  datasource:
+    url: jdbc:h2:file:./data/book_db
+    driver-class-name: org.h2.Driver
+    username: sa
+    password:
+  jpa:
+    hibernate:
+      ddl-auto: update
+    database-platform: org.hibernate.dialect.H2Dialect
+    properties:
+      hibernate:
+        show_sql: true
+        format_sql: true
+        use_sql_comments: true
+
+  h2:
+    console:
+      enabled: true
+      path: /h2-console


### PR DESCRIPTION
## 작업 상세 내용
- [x] 요구사항에 맞게 엔티티 객체 구현
  ```
  - 저자 (Author)
    - id: PK(자동생성)
    - name: 저자 이름 (필수)
    - email: 이메일 (필수, 고유)
  - 도서 (Book)
    - id: PK(자동생성)
    - title: 도서 제목(필수)
    - description: 도서 설명 (선택)
    - isbn: 국제 표준 도서번호 (필수, 고유)
    - publication_date: 출판일 (선택)
    - author_id: 해당 도서의 저자 (필수, Author와의 관계)
  ```
- [x] 연관관계 설정 (Book → Author 으로 `ManyToOne` 단방향 설정)
- [x] `application.yml` 설정 및 H2 DB 연동 설정 추가 (`./data/book_db`에 저장)


## 이슈 링크
- #1 