### PR TITLE
feat: Author CRUD 기능 구현

### DIFF
--- a/src/main/java/com/hwk9407/bookmanagementassignment/api/author/controller/AuthorController.java
+++ b/src/main/java/com/hwk9407/bookmanagementassignment/api/author/controller/AuthorController.java
@@ -2,9 +2,13 @@ package com.hwk9407.bookmanagementassignment.api.author.controller;
 
 import com.hwk9407.bookmanagementassignment.api.author.dto.request.AddAuthorRequest;
 import com.hwk9407.bookmanagementassignment.api.author.dto.response.AddAuthorResponse;
+import com.hwk9407.bookmanagementassignment.api.author.dto.response.RetrieveAllAuthorsResponse;
 import com.hwk9407.bookmanagementassignment.api.author.service.AuthorService;
+import com.hwk9407.bookmanagementassignment.api.book.dto.response.RetrieveAllBooksResponse;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
@@ -25,4 +29,11 @@ public class AuthorController {
                 .build();
     }
 
+    @GetMapping("/authors")
+    public ResponseEntity<RetrieveAllAuthorsResponse> retrieveAllAuthors() { // todo: 페이지네이션 적용 필요
+        RetrieveAllAuthorsResponse res = authorService.retrieveAllAuthors();
+        return ResponseEntity
+                .status(HttpStatus.OK)
+                .body(res);
+    }
 }

--- a/src/main/java/com/hwk9407/bookmanagementassignment/api/author/controller/AuthorController.java
+++ b/src/main/java/com/hwk9407/bookmanagementassignment/api/author/controller/AuthorController.java
@@ -3,15 +3,12 @@ package com.hwk9407.bookmanagementassignment.api.author.controller;
 import com.hwk9407.bookmanagementassignment.api.author.dto.request.AddAuthorRequest;
 import com.hwk9407.bookmanagementassignment.api.author.dto.response.AddAuthorResponse;
 import com.hwk9407.bookmanagementassignment.api.author.dto.response.RetrieveAllAuthorsResponse;
+import com.hwk9407.bookmanagementassignment.api.author.dto.response.RetrieveAuthorResponse;
 import com.hwk9407.bookmanagementassignment.api.author.service.AuthorService;
-import com.hwk9407.bookmanagementassignment.api.book.dto.response.RetrieveAllBooksResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import java.net.URI;
 
@@ -32,6 +29,14 @@ public class AuthorController {
     @GetMapping("/authors")
     public ResponseEntity<RetrieveAllAuthorsResponse> retrieveAllAuthors() { // todo: 페이지네이션 적용 필요
         RetrieveAllAuthorsResponse res = authorService.retrieveAllAuthors();
+        return ResponseEntity
+                .status(HttpStatus.OK)
+                .body(res);
+    }
+
+    @GetMapping("/authors/{id}")
+    public ResponseEntity<RetrieveAuthorResponse> retrieveAuthor (@PathVariable Long id) {
+        RetrieveAuthorResponse res = authorService.retrieveAuthor(id);
         return ResponseEntity
                 .status(HttpStatus.OK)
                 .body(res);

--- a/src/main/java/com/hwk9407/bookmanagementassignment/api/author/controller/AuthorController.java
+++ b/src/main/java/com/hwk9407/bookmanagementassignment/api/author/controller/AuthorController.java
@@ -1,0 +1,28 @@
+package com.hwk9407.bookmanagementassignment.api.author.controller;
+
+import com.hwk9407.bookmanagementassignment.api.author.dto.request.AddAuthorRequest;
+import com.hwk9407.bookmanagementassignment.api.author.dto.response.AddAuthorResponse;
+import com.hwk9407.bookmanagementassignment.api.author.service.AuthorService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.net.URI;
+
+@RestController
+@RequiredArgsConstructor
+public class AuthorController {
+
+    private final AuthorService authorService;
+
+    @PostMapping("/authors")
+    public ResponseEntity<Void> addAuthor(@RequestBody AddAuthorRequest req) {
+        AddAuthorResponse res = authorService.addAuthor(req);
+        return ResponseEntity
+                .created(URI.create(String.valueOf(res.id())))
+                .build();
+    }
+
+}

--- a/src/main/java/com/hwk9407/bookmanagementassignment/api/author/controller/AuthorController.java
+++ b/src/main/java/com/hwk9407/bookmanagementassignment/api/author/controller/AuthorController.java
@@ -21,7 +21,7 @@ public class AuthorController {
     private final AuthorService authorService;
 
     @PostMapping("/authors")
-    public ResponseEntity<Void> addAuthor(@RequestBody AddAuthorRequest req) {
+    public ResponseEntity<Void> addAuthor(@Valid @RequestBody AddAuthorRequest req) {
         AddAuthorResponse res = authorService.addAuthor(req);
         return ResponseEntity
                 .created(URI.create(String.valueOf(res.id())))

--- a/src/main/java/com/hwk9407/bookmanagementassignment/api/author/controller/AuthorController.java
+++ b/src/main/java/com/hwk9407/bookmanagementassignment/api/author/controller/AuthorController.java
@@ -1,10 +1,12 @@
 package com.hwk9407.bookmanagementassignment.api.author.controller;
 
 import com.hwk9407.bookmanagementassignment.api.author.dto.request.AddAuthorRequest;
+import com.hwk9407.bookmanagementassignment.api.author.dto.request.UpdateAuthorRequest;
 import com.hwk9407.bookmanagementassignment.api.author.dto.response.AddAuthorResponse;
 import com.hwk9407.bookmanagementassignment.api.author.dto.response.RetrieveAllAuthorsResponse;
 import com.hwk9407.bookmanagementassignment.api.author.dto.response.RetrieveAuthorResponse;
 import com.hwk9407.bookmanagementassignment.api.author.service.AuthorService;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -40,5 +42,13 @@ public class AuthorController {
         return ResponseEntity
                 .status(HttpStatus.OK)
                 .body(res);
+    }
+
+    @PatchMapping("/authors/{id}")
+    public ResponseEntity<Void> updateAuthor (@PathVariable Long id, @Valid @RequestBody UpdateAuthorRequest req) {
+        authorService.updateAuthor(id, req);
+        return ResponseEntity
+                .ok()
+                .build();
     }
 }

--- a/src/main/java/com/hwk9407/bookmanagementassignment/api/author/controller/AuthorController.java
+++ b/src/main/java/com/hwk9407/bookmanagementassignment/api/author/controller/AuthorController.java
@@ -51,4 +51,12 @@ public class AuthorController {
                 .ok()
                 .build();
     }
+
+    @DeleteMapping("/authors/{id}")
+    public ResponseEntity<Void> deleteAuthor (@PathVariable Long id) {
+        authorService.deleteAuthor(id);
+        return ResponseEntity
+                .noContent()
+                .build();
+    }
 }

--- a/src/main/java/com/hwk9407/bookmanagementassignment/api/author/dto/request/AddAuthorRequest.java
+++ b/src/main/java/com/hwk9407/bookmanagementassignment/api/author/dto/request/AddAuthorRequest.java
@@ -1,0 +1,18 @@
+package com.hwk9407.bookmanagementassignment.api.author.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+
+public record AddAuthorRequest(
+
+        @NotBlank
+        String name,
+
+        @NotBlank
+        @Pattern(
+                regexp = "^[a-zA-Z0-9._+-]+@[a-zA-Z0-9.-]+\\.[a-zA-Z]{2,6}$",
+                message = "올바른 이메일 형식을 입력해주세요."
+        )
+        String email
+) {
+}

--- a/src/main/java/com/hwk9407/bookmanagementassignment/api/author/dto/request/UpdateAuthorRequest.java
+++ b/src/main/java/com/hwk9407/bookmanagementassignment/api/author/dto/request/UpdateAuthorRequest.java
@@ -1,0 +1,19 @@
+package com.hwk9407.bookmanagementassignment.api.author.dto.request;
+
+import jakarta.validation.constraints.Pattern;
+
+public record UpdateAuthorRequest(
+
+        @Pattern(
+                regexp = "^(?=.*[a-zA-Z가-힣])[a-zA-Z가-힣\\s]{1,30}$",
+                message = "이름은 한글 또는 영어만 30글자 내로 입력 가능하며, 빈 문자열이나 공백만 입력할 수 없습니다."
+        )
+        String name,
+
+        @Pattern(
+                regexp = "^[a-zA-Z0-9._+-]+@[a-zA-Z0-9.-]+\\.[a-zA-Z]{2,6}$",
+                message = "올바른 이메일 형식을 입력해주세요."
+        )
+        String email
+) {
+}

--- a/src/main/java/com/hwk9407/bookmanagementassignment/api/author/dto/response/AddAuthorResponse.java
+++ b/src/main/java/com/hwk9407/bookmanagementassignment/api/author/dto/response/AddAuthorResponse.java
@@ -1,0 +1,6 @@
+package com.hwk9407.bookmanagementassignment.api.author.dto.response;
+
+public record AddAuthorResponse(
+        Long id
+) {
+}

--- a/src/main/java/com/hwk9407/bookmanagementassignment/api/author/dto/response/RetrieveAllAuthorsResponse.java
+++ b/src/main/java/com/hwk9407/bookmanagementassignment/api/author/dto/response/RetrieveAllAuthorsResponse.java
@@ -1,0 +1,18 @@
+package com.hwk9407.bookmanagementassignment.api.author.dto.response;
+
+import com.hwk9407.bookmanagementassignment.domain.author.Author;
+
+import java.util.List;
+
+public record RetrieveAllAuthorsResponse(
+        List<RetrieveAuthorResponse> contents
+) {
+
+    public static RetrieveAllAuthorsResponse from(List<Author> authors) {
+        return new RetrieveAllAuthorsResponse(
+                authors.stream()
+                        .map(RetrieveAuthorResponse::from)
+                        .toList()
+        );
+    }
+}

--- a/src/main/java/com/hwk9407/bookmanagementassignment/api/author/dto/response/RetrieveAuthorResponse.java
+++ b/src/main/java/com/hwk9407/bookmanagementassignment/api/author/dto/response/RetrieveAuthorResponse.java
@@ -1,0 +1,16 @@
+package com.hwk9407.bookmanagementassignment.api.author.dto.response;
+
+import com.hwk9407.bookmanagementassignment.domain.author.Author;
+
+public record RetrieveAuthorResponse(
+        String name,
+        String email
+) {
+
+    public static RetrieveAuthorResponse from(Author author) {
+        return new RetrieveAuthorResponse(
+                author.getName(),
+                author.getEmail()
+        );
+    }
+}

--- a/src/main/java/com/hwk9407/bookmanagementassignment/api/author/service/AuthorService.java
+++ b/src/main/java/com/hwk9407/bookmanagementassignment/api/author/service/AuthorService.java
@@ -3,9 +3,11 @@ package com.hwk9407.bookmanagementassignment.api.author.service;
 import com.hwk9407.bookmanagementassignment.api.author.dto.request.AddAuthorRequest;
 import com.hwk9407.bookmanagementassignment.api.author.dto.response.AddAuthorResponse;
 import com.hwk9407.bookmanagementassignment.api.author.dto.response.RetrieveAllAuthorsResponse;
+import com.hwk9407.bookmanagementassignment.api.author.dto.response.RetrieveAuthorResponse;
 import com.hwk9407.bookmanagementassignment.domain.author.Author;
 import com.hwk9407.bookmanagementassignment.domain.author.AuthorRepository;
 import com.hwk9407.bookmanagementassignment.exception.EmailAlreadyExistsException;
+import jakarta.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -34,5 +36,13 @@ public class AuthorService {
     public RetrieveAllAuthorsResponse retrieveAllAuthors() {
         List<Author> authors = authorRepository.findAll();
         return RetrieveAllAuthorsResponse.from(authors);
+    }
+
+    @Transactional(readOnly = true)
+    public RetrieveAuthorResponse retrieveAuthor(Long id) {
+        Author author = authorRepository.findById(id).orElseThrow(
+                () -> new EntityNotFoundException("조회되지 않는 저자 ID 입니다.")
+        );
+        return RetrieveAuthorResponse.from(author);
     }
 }

--- a/src/main/java/com/hwk9407/bookmanagementassignment/api/author/service/AuthorService.java
+++ b/src/main/java/com/hwk9407/bookmanagementassignment/api/author/service/AuthorService.java
@@ -1,0 +1,21 @@
+package com.hwk9407.bookmanagementassignment.api.author.service;
+
+import com.hwk9407.bookmanagementassignment.api.author.dto.request.AddAuthorRequest;
+import com.hwk9407.bookmanagementassignment.api.author.dto.response.AddAuthorResponse;
+import com.hwk9407.bookmanagementassignment.domain.author.AuthorRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class AuthorService {
+
+    private final AuthorRepository authorRepository;
+
+    public AddAuthorResponse addAuthor(AddAuthorRequest req) {
+        // DB에 이메일이 중복됐는지 확인
+        // 없으면 DB 저장
+        // id 값 Response Dto에 저장 후 반환
+        return null;
+    }
+}

--- a/src/main/java/com/hwk9407/bookmanagementassignment/api/author/service/AuthorService.java
+++ b/src/main/java/com/hwk9407/bookmanagementassignment/api/author/service/AuthorService.java
@@ -50,8 +50,15 @@ public class AuthorService {
 
     @Transactional
     public void updateAuthor(Long id, @Valid UpdateAuthorRequest req) {
-        // DB에 저자 id가 있는지 확인 없으면 예외 처리
-        // 바꾸려는 이메일이 현재 이메일과 기존 이메일과 다르고, DB에 존재하는 이메일 이라면 예외 처리
-        // Author update 메서드로 수정 행위 위임
+        Author author = authorRepository.findById(id).orElseThrow(
+                () -> new EntityNotFoundException("조회되지 않는 저자 ID 입니다.")
+        );
+        if (req.email() != null && !author.getEmail().equals(req.email()) && authorRepository.existsByEmail(req.email())) {
+            throw new EmailAlreadyExistsException("이미 존재하는 이메일입니다.");
+        }
+        author.update(
+                req.name(),
+                req.email()
+        );
     }
 }

--- a/src/main/java/com/hwk9407/bookmanagementassignment/api/author/service/AuthorService.java
+++ b/src/main/java/com/hwk9407/bookmanagementassignment/api/author/service/AuthorService.java
@@ -2,6 +2,7 @@ package com.hwk9407.bookmanagementassignment.api.author.service;
 
 import com.hwk9407.bookmanagementassignment.api.author.dto.request.AddAuthorRequest;
 import com.hwk9407.bookmanagementassignment.api.author.dto.response.AddAuthorResponse;
+import com.hwk9407.bookmanagementassignment.api.author.dto.response.RetrieveAllAuthorsResponse;
 import com.hwk9407.bookmanagementassignment.domain.author.Author;
 import com.hwk9407.bookmanagementassignment.domain.author.AuthorRepository;
 import com.hwk9407.bookmanagementassignment.exception.EmailAlreadyExistsException;
@@ -25,5 +26,11 @@ public class AuthorService {
                 .email(req.email())
                 .build());
         return new AddAuthorResponse(author.getId());
+    }
+
+    public RetrieveAllAuthorsResponse retrieveAllAuthors() {
+        // DB에서 전체 저자를 조회하고 List<Author> 에 담음
+        // response Dto 파라미터에 넣어 반환
+        return null;
     }
 }

--- a/src/main/java/com/hwk9407/bookmanagementassignment/api/author/service/AuthorService.java
+++ b/src/main/java/com/hwk9407/bookmanagementassignment/api/author/service/AuthorService.java
@@ -1,6 +1,7 @@
 package com.hwk9407.bookmanagementassignment.api.author.service;
 
 import com.hwk9407.bookmanagementassignment.api.author.dto.request.AddAuthorRequest;
+import com.hwk9407.bookmanagementassignment.api.author.dto.request.UpdateAuthorRequest;
 import com.hwk9407.bookmanagementassignment.api.author.dto.response.AddAuthorResponse;
 import com.hwk9407.bookmanagementassignment.api.author.dto.response.RetrieveAllAuthorsResponse;
 import com.hwk9407.bookmanagementassignment.api.author.dto.response.RetrieveAuthorResponse;
@@ -8,6 +9,7 @@ import com.hwk9407.bookmanagementassignment.domain.author.Author;
 import com.hwk9407.bookmanagementassignment.domain.author.AuthorRepository;
 import com.hwk9407.bookmanagementassignment.exception.EmailAlreadyExistsException;
 import jakarta.persistence.EntityNotFoundException;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -44,5 +46,12 @@ public class AuthorService {
                 () -> new EntityNotFoundException("조회되지 않는 저자 ID 입니다.")
         );
         return RetrieveAuthorResponse.from(author);
+    }
+
+    @Transactional
+    public void updateAuthor(Long id, @Valid UpdateAuthorRequest req) {
+        // DB에 저자 id가 있는지 확인 없으면 예외 처리
+        // 바꾸려는 이메일이 현재 이메일과 기존 이메일과 다르고, DB에 존재하는 이메일 이라면 예외 처리
+        // Author update 메서드로 수정 행위 위임
     }
 }

--- a/src/main/java/com/hwk9407/bookmanagementassignment/api/author/service/AuthorService.java
+++ b/src/main/java/com/hwk9407/bookmanagementassignment/api/author/service/AuthorService.java
@@ -2,9 +2,12 @@ package com.hwk9407.bookmanagementassignment.api.author.service;
 
 import com.hwk9407.bookmanagementassignment.api.author.dto.request.AddAuthorRequest;
 import com.hwk9407.bookmanagementassignment.api.author.dto.response.AddAuthorResponse;
+import com.hwk9407.bookmanagementassignment.domain.author.Author;
 import com.hwk9407.bookmanagementassignment.domain.author.AuthorRepository;
+import com.hwk9407.bookmanagementassignment.exception.EmailAlreadyExistsException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
@@ -12,10 +15,15 @@ public class AuthorService {
 
     private final AuthorRepository authorRepository;
 
+    @Transactional
     public AddAuthorResponse addAuthor(AddAuthorRequest req) {
-        // DB에 이메일이 중복됐는지 확인
-        // 없으면 DB 저장
-        // id 값 Response Dto에 저장 후 반환
-        return null;
+        if (authorRepository.existsByEmail(req.email())) {
+            throw new EmailAlreadyExistsException("이미 존재하는 이메일입니다.");
+        }
+        Author author = authorRepository.save(Author.builder()
+                .name(req.name())
+                .email(req.email())
+                .build());
+        return new AddAuthorResponse(author.getId());
     }
 }

--- a/src/main/java/com/hwk9407/bookmanagementassignment/api/author/service/AuthorService.java
+++ b/src/main/java/com/hwk9407/bookmanagementassignment/api/author/service/AuthorService.java
@@ -7,6 +7,8 @@ import com.hwk9407.bookmanagementassignment.api.author.dto.response.RetrieveAllA
 import com.hwk9407.bookmanagementassignment.api.author.dto.response.RetrieveAuthorResponse;
 import com.hwk9407.bookmanagementassignment.domain.author.Author;
 import com.hwk9407.bookmanagementassignment.domain.author.AuthorRepository;
+import com.hwk9407.bookmanagementassignment.domain.book.BookRepository;
+import com.hwk9407.bookmanagementassignment.exception.CannotDeleteAuthorException;
 import com.hwk9407.bookmanagementassignment.exception.EmailAlreadyExistsException;
 import jakarta.persistence.EntityNotFoundException;
 import jakarta.validation.Valid;
@@ -21,6 +23,7 @@ import java.util.List;
 public class AuthorService {
 
     private final AuthorRepository authorRepository;
+    private final BookRepository bookRepository;
 
     @Transactional
     public AddAuthorResponse addAuthor(AddAuthorRequest req) {
@@ -60,5 +63,16 @@ public class AuthorService {
                 req.name(),
                 req.email()
         );
+    }
+
+    @Transactional
+    public void deleteAuthor(Long id) {
+        Author author = authorRepository.findById(id).orElseThrow(
+                () -> new EntityNotFoundException("조회되지 않는 저자 ID 입니다.")
+        );
+        if (bookRepository.existsByAuthor(author)) {
+            throw new CannotDeleteAuthorException("연관된 책이 존재하여 저자를 삭제할 수 없습니다.");
+        }
+        authorRepository.delete(author);
     }
 }

--- a/src/main/java/com/hwk9407/bookmanagementassignment/api/author/service/AuthorService.java
+++ b/src/main/java/com/hwk9407/bookmanagementassignment/api/author/service/AuthorService.java
@@ -10,6 +10,8 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.List;
+
 @Service
 @RequiredArgsConstructor
 public class AuthorService {
@@ -28,9 +30,9 @@ public class AuthorService {
         return new AddAuthorResponse(author.getId());
     }
 
+    @Transactional(readOnly = true)
     public RetrieveAllAuthorsResponse retrieveAllAuthors() {
-        // DB에서 전체 저자를 조회하고 List<Author> 에 담음
-        // response Dto 파라미터에 넣어 반환
-        return null;
+        List<Author> authors = authorRepository.findAll();
+        return RetrieveAllAuthorsResponse.from(authors);
     }
 }

--- a/src/main/java/com/hwk9407/bookmanagementassignment/domain/author/Author.java
+++ b/src/main/java/com/hwk9407/bookmanagementassignment/domain/author/Author.java
@@ -1,9 +1,12 @@
 package com.hwk9407.bookmanagementassignment.domain.author;
 
 import jakarta.persistence.*;
+import jakarta.validation.constraints.Pattern;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+
+import java.util.Objects;
 
 @Entity
 @Getter
@@ -23,5 +26,10 @@ public class Author {
     public Author(String name, String email) {
         this.name = name;
         this.email = email;
+    }
+
+    public void update(String name, String email) {
+        this.name = Objects.requireNonNull(name, this.name);
+        this.email = Objects.requireNonNull(email, this.email);
     }
 }

--- a/src/main/java/com/hwk9407/bookmanagementassignment/domain/author/AuthorRepository.java
+++ b/src/main/java/com/hwk9407/bookmanagementassignment/domain/author/AuthorRepository.java
@@ -3,4 +3,5 @@ package com.hwk9407.bookmanagementassignment.domain.author;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface AuthorRepository extends JpaRepository<Author, Long> {
+    boolean existsByEmail(String email);
 }

--- a/src/main/java/com/hwk9407/bookmanagementassignment/domain/book/BookRepository.java
+++ b/src/main/java/com/hwk9407/bookmanagementassignment/domain/book/BookRepository.java
@@ -1,8 +1,11 @@
 package com.hwk9407.bookmanagementassignment.domain.book;
 
+ import com.hwk9407.bookmanagementassignment.domain.author.Author;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface BookRepository extends JpaRepository<Book, Long> {
 
     boolean existsByIsbn(String isbn);
+
+    boolean existsByAuthor(Author author);
 }

--- a/src/main/java/com/hwk9407/bookmanagementassignment/exception/CannotDeleteAuthorException.java
+++ b/src/main/java/com/hwk9407/bookmanagementassignment/exception/CannotDeleteAuthorException.java
@@ -1,0 +1,7 @@
+package com.hwk9407.bookmanagementassignment.exception;
+
+public class CannotDeleteAuthorException extends RuntimeException {
+    public CannotDeleteAuthorException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/hwk9407/bookmanagementassignment/exception/EmailAlreadyExistsException.java
+++ b/src/main/java/com/hwk9407/bookmanagementassignment/exception/EmailAlreadyExistsException.java
@@ -1,0 +1,7 @@
+package com.hwk9407.bookmanagementassignment.exception;
+
+public class EmailAlreadyExistsException extends RuntimeException {
+    public EmailAlreadyExistsException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/hwk9407/bookmanagementassignment/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/hwk9407/bookmanagementassignment/exception/GlobalExceptionHandler.java
@@ -68,4 +68,14 @@ public class GlobalExceptionHandler {
                 .status(status)
                 .body(errorResponse);
     }
+
+    @ExceptionHandler(CannotDeleteAuthorException.class)
+    public ResponseEntity<ErrorResponse> cannotDeleteAuthorException(CannotDeleteAuthorException e) {
+        HttpStatus status = HttpStatus.CONFLICT; // 409 Conflict
+        ErrorResponse errorResponse = ErrorResponse.of(status.value(), LocalDateTime.now(), e.getMessage());
+
+        return ResponseEntity
+                .status(status)
+                .body(errorResponse);
+    }
 }

--- a/src/main/java/com/hwk9407/bookmanagementassignment/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/hwk9407/bookmanagementassignment/exception/GlobalExceptionHandler.java
@@ -58,4 +58,14 @@ public class GlobalExceptionHandler {
                 .status(status)
                 .body(errorResponse);
     }
+
+    @ExceptionHandler(EmailAlreadyExistsException.class)
+    public ResponseEntity<ErrorResponse> emailAlreadyExistsException(EmailAlreadyExistsException e) {
+        HttpStatus status = HttpStatus.CONFLICT; // 409 Conflict
+        ErrorResponse errorResponse = ErrorResponse.of(status.value(), LocalDateTime.now(), e.getMessage());
+
+        return ResponseEntity
+                .status(status)
+                .body(errorResponse);
+    }
 }


### PR DESCRIPTION
## 작업 상세 내용
- 저자 (Author) CRUD 구현
  - [x] 저자 등록 (`POST /authors`)
  - [x] 저자 목록 조회 (`GET /authors`)
  - [x] 저자 상세 조회 (`GET /authors/{id}`)
  - [x] 저자 정보 수정 (`PUT /authors/{id}`)
  - [x] 저자 삭제 (`DELETE /authors/{id}`)
- 삭제 전, 해당 저자와 연관된 도서 처리(삭제 불가 혹은 연관 도서 삭제 여부에 대한 정책 명시 필요)
- 예외 처리 추가
  - [x] 이미 존재하는 이메일로 생성 / 수정 요청 시 409 예외 처리 (`EmailAlreadyExistsException`)
  - [x] 저자 생성, 수정 Request Body에 Validation 실패 시 400 예외 처리 (`MethodArgumentNotValidException`)
  - [x] 엔티티 조회 안될 시 404 예외 처리 (`EntityNotFoundException`)
  - [x] 저자 삭제 시도 중 저자와 연관된 Book 데이터 존재 시 409 예외 처리 (`CannotDeleteAuthorException`)

## 앞으로의 과제
- [x] 저자 목록 조회 시 페이지네이션
- [ ] 적합한 권한이 있는 사용자의 요청만 수정 및 삭제 가능하도록 변경
- [x] Author CRUD 통합 테스트 작성

## 이슈 링크
- #5 