### PR TITLE
Pagination 및 필터링 기능 추가 및 리펙토링

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -20,10 +20,16 @@ configurations {
 }
 
 repositories {
+    mavenLocal()
     mavenCentral()
 }
 
 dependencies {
+    implementation 'com.querydsl:querydsl-jpa:5.1.0:jakarta'
+    annotationProcessor "com.querydsl:querydsl-apt:${dependencyManagement.importedProperties['querydsl.version']}:jakarta"
+    annotationProcessor 'jakarta.annotation:jakarta.annotation-api'
+    annotationProcessor 'jakarta.persistence:jakarta.persistence-api'
+
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springframework.boot:spring-boot-starter-web'

--- a/src/main/java/com/hwk9407/bookmanagementassignment/api/author/controller/AuthorController.java
+++ b/src/main/java/com/hwk9407/bookmanagementassignment/api/author/controller/AuthorController.java
@@ -1,11 +1,14 @@
 package com.hwk9407.bookmanagementassignment.api.author.controller;
 
 import com.hwk9407.bookmanagementassignment.api.author.dto.request.AddAuthorRequest;
+import com.hwk9407.bookmanagementassignment.api.author.dto.request.RetrieveAllAuthorsRequest;
 import com.hwk9407.bookmanagementassignment.api.author.dto.request.UpdateAuthorRequest;
 import com.hwk9407.bookmanagementassignment.api.author.dto.response.AddAuthorResponse;
 import com.hwk9407.bookmanagementassignment.api.author.dto.response.RetrieveAllAuthorsResponse;
 import com.hwk9407.bookmanagementassignment.api.author.dto.response.RetrieveAuthorResponse;
 import com.hwk9407.bookmanagementassignment.api.author.service.AuthorService;
+import com.hwk9407.bookmanagementassignment.api.book.dto.request.RetrieveAllBooksRequest;
+import com.hwk9407.bookmanagementassignment.util.DtoValidator;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -19,6 +22,7 @@ import java.net.URI;
 public class AuthorController {
 
     private final AuthorService authorService;
+    private final DtoValidator dtoValidator;
 
     @PostMapping("/authors")
     public ResponseEntity<Void> addAuthor(@Valid @RequestBody AddAuthorRequest req) {
@@ -29,8 +33,13 @@ public class AuthorController {
     }
 
     @GetMapping("/authors")
-    public ResponseEntity<RetrieveAllAuthorsResponse> retrieveAllAuthors() { // todo: 페이지네이션 적용 필요
-        RetrieveAllAuthorsResponse res = authorService.retrieveAllAuthors();
+    public ResponseEntity<RetrieveAllAuthorsResponse> retrieveAllAuthors(
+            @RequestParam(defaultValue = "1") int page,
+            @RequestParam(defaultValue = "10") int size
+    ) {
+        RetrieveAllAuthorsRequest req = new RetrieveAllAuthorsRequest(page, size);
+        dtoValidator.validate(req);
+        RetrieveAllAuthorsResponse res = authorService.retrieveAllAuthors(req);
         return ResponseEntity
                 .status(HttpStatus.OK)
                 .body(res);

--- a/src/main/java/com/hwk9407/bookmanagementassignment/api/author/dto/request/AddAuthorRequest.java
+++ b/src/main/java/com/hwk9407/bookmanagementassignment/api/author/dto/request/AddAuthorRequest.java
@@ -6,12 +6,16 @@ import jakarta.validation.constraints.Pattern;
 public record AddAuthorRequest(
 
         @NotBlank
+        @Pattern(
+                regexp = "^(?=.*[a-zA-Z가-힣])[a-zA-Z가-힣\\s]{1,30}$",
+                message = "이름은 한글 또는 영어만 30글자 내로 입력 가능하며, 빈 문자열이나 공백만 입력할 수 없습니다"
+        )
         String name,
 
         @NotBlank
         @Pattern(
                 regexp = "^[a-zA-Z0-9._+-]+@[a-zA-Z0-9.-]+\\.[a-zA-Z]{2,6}$",
-                message = "올바른 이메일 형식을 입력해주세요."
+                message = "올바른 이메일 형식을 입력해주세요"
         )
         String email
 ) {

--- a/src/main/java/com/hwk9407/bookmanagementassignment/api/author/dto/request/RetrieveAllAuthorsRequest.java
+++ b/src/main/java/com/hwk9407/bookmanagementassignment/api/author/dto/request/RetrieveAllAuthorsRequest.java
@@ -1,0 +1,15 @@
+package com.hwk9407.bookmanagementassignment.api.author.dto.request;
+
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.Positive;
+
+public record RetrieveAllAuthorsRequest(
+
+        @Positive(message = "자연수만 입력할 수 있습니다")
+        Integer page,
+
+        @Min(1) @Max(50)
+        Integer size
+) {
+}

--- a/src/main/java/com/hwk9407/bookmanagementassignment/api/author/dto/request/UpdateAuthorRequest.java
+++ b/src/main/java/com/hwk9407/bookmanagementassignment/api/author/dto/request/UpdateAuthorRequest.java
@@ -6,13 +6,13 @@ public record UpdateAuthorRequest(
 
         @Pattern(
                 regexp = "^(?=.*[a-zA-Z가-힣])[a-zA-Z가-힣\\s]{1,30}$",
-                message = "이름은 한글 또는 영어만 30글자 내로 입력 가능하며, 빈 문자열이나 공백만 입력할 수 없습니다."
+                message = "이름은 한글 또는 영어만 30글자 내로 입력 가능하며, 빈 문자열이나 공백만 입력할 수 없습니다"
         )
         String name,
 
         @Pattern(
                 regexp = "^[a-zA-Z0-9._+-]+@[a-zA-Z0-9.-]+\\.[a-zA-Z]{2,6}$",
-                message = "올바른 이메일 형식을 입력해주세요."
+                message = "올바른 이메일 형식을 입력해주세요"
         )
         String email
 ) {

--- a/src/main/java/com/hwk9407/bookmanagementassignment/api/author/dto/response/RetrieveAllAuthorsResponse.java
+++ b/src/main/java/com/hwk9407/bookmanagementassignment/api/author/dto/response/RetrieveAllAuthorsResponse.java
@@ -1,18 +1,26 @@
 package com.hwk9407.bookmanagementassignment.api.author.dto.response;
 
 import com.hwk9407.bookmanagementassignment.domain.author.Author;
+import org.springframework.data.domain.Page;
 
 import java.util.List;
 
 public record RetrieveAllAuthorsResponse(
-        List<RetrieveAuthorResponse> contents
+        List<RetrieveAuthorResponse> contents,
+        int page,
+        int size,
+        int totalPage
 ) {
 
-    public static RetrieveAllAuthorsResponse from(List<Author> authors) {
+    public static RetrieveAllAuthorsResponse from(Page<Author> authors) {
         return new RetrieveAllAuthorsResponse(
-                authors.stream()
+                authors.getContent().stream()
                         .map(RetrieveAuthorResponse::from)
-                        .toList()
+                        .toList(),
+                authors.getNumber() + 1,
+                authors.getSize(),
+                authors.getTotalPages()
+
         );
     }
 }

--- a/src/main/java/com/hwk9407/bookmanagementassignment/api/author/dto/response/RetrieveAuthorResponse.java
+++ b/src/main/java/com/hwk9407/bookmanagementassignment/api/author/dto/response/RetrieveAuthorResponse.java
@@ -3,12 +3,14 @@ package com.hwk9407.bookmanagementassignment.api.author.dto.response;
 import com.hwk9407.bookmanagementassignment.domain.author.Author;
 
 public record RetrieveAuthorResponse(
+        Long id,
         String name,
         String email
 ) {
 
     public static RetrieveAuthorResponse from(Author author) {
         return new RetrieveAuthorResponse(
+                author.getId(),
                 author.getName(),
                 author.getEmail()
         );

--- a/src/main/java/com/hwk9407/bookmanagementassignment/api/author/service/AuthorService.java
+++ b/src/main/java/com/hwk9407/bookmanagementassignment/api/author/service/AuthorService.java
@@ -1,6 +1,7 @@
 package com.hwk9407.bookmanagementassignment.api.author.service;
 
 import com.hwk9407.bookmanagementassignment.api.author.dto.request.AddAuthorRequest;
+import com.hwk9407.bookmanagementassignment.api.author.dto.request.RetrieveAllAuthorsRequest;
 import com.hwk9407.bookmanagementassignment.api.author.dto.request.UpdateAuthorRequest;
 import com.hwk9407.bookmanagementassignment.api.author.dto.response.AddAuthorResponse;
 import com.hwk9407.bookmanagementassignment.api.author.dto.response.RetrieveAllAuthorsResponse;
@@ -13,6 +14,10 @@ import com.hwk9407.bookmanagementassignment.exception.EmailAlreadyExistsExceptio
 import jakarta.persistence.EntityNotFoundException;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -38,8 +43,9 @@ public class AuthorService {
     }
 
     @Transactional(readOnly = true)
-    public RetrieveAllAuthorsResponse retrieveAllAuthors() {
-        List<Author> authors = authorRepository.findAll();
+    public RetrieveAllAuthorsResponse retrieveAllAuthors(RetrieveAllAuthorsRequest req) {
+        Pageable pageable = PageRequest.of(req.page() - 1, req.size());
+        Page<Author> authors = authorRepository.findAll(pageable);
         return RetrieveAllAuthorsResponse.from(authors);
     }
 

--- a/src/main/java/com/hwk9407/bookmanagementassignment/api/book/controller/BookController.java
+++ b/src/main/java/com/hwk9407/bookmanagementassignment/api/book/controller/BookController.java
@@ -1,11 +1,13 @@
 package com.hwk9407.bookmanagementassignment.api.book.controller;
 
 import com.hwk9407.bookmanagementassignment.api.book.dto.request.AddBookRequest;
+import com.hwk9407.bookmanagementassignment.api.book.dto.request.RetrieveAllBooksRequest;
 import com.hwk9407.bookmanagementassignment.api.book.dto.request.UpdateBookRequest;
 import com.hwk9407.bookmanagementassignment.api.book.dto.response.AddBookResponse;
 import com.hwk9407.bookmanagementassignment.api.book.dto.response.RetrieveAllBooksResponse;
 import com.hwk9407.bookmanagementassignment.api.book.dto.response.RetrieveBookResponse;
 import com.hwk9407.bookmanagementassignment.api.book.service.BookService;
+import com.hwk9407.bookmanagementassignment.util.DtoValidator;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -13,12 +15,14 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 import java.net.URI;
+import java.time.LocalDate;
 
 @RestController
 @RequiredArgsConstructor
 public class BookController {
 
     private final BookService bookService;
+    private final DtoValidator dtoValidator;
 
     @PostMapping("/books")
     public ResponseEntity<Void> addBook(@Valid @RequestBody AddBookRequest req) {
@@ -29,15 +33,30 @@ public class BookController {
     }
 
     @GetMapping("/books")
-    public ResponseEntity<RetrieveAllBooksResponse> retrieveAllBooks () { // todo: 페이지네이션 적용 필요
-        RetrieveAllBooksResponse res = bookService.retrieveAllBooks();
+    public ResponseEntity<RetrieveAllBooksResponse> retrieveAllBooks(
+            @RequestParam(defaultValue = "1") int page,
+            @RequestParam(defaultValue = "10") int size,
+            @RequestParam(defaultValue = "DESC") String orderBy,
+            @RequestParam(defaultValue = "publicationDate") String sortBy,
+            @RequestParam(required = false) Long authorId,
+            @RequestParam(required = false) LocalDate startPubDate,
+            @RequestParam(required = false) LocalDate endPubDate
+    ) {
+        RetrieveAllBooksRequest req = new RetrieveAllBooksRequest(page, size, orderBy, sortBy, authorId, startPubDate, endPubDate);
+        dtoValidator.validate(req);
+        if (startPubDate != null && endPubDate != null) {
+            if (startPubDate.isAfter(endPubDate)) {
+                throw new IllegalArgumentException("종료일을 시작일보다 이전으로 조회할 수 없습니다.");
+            }
+        }
+        RetrieveAllBooksResponse res = bookService.retrieveAllBooks(req);
         return ResponseEntity
                 .status(HttpStatus.OK)
                 .body(res);
     }
 
     @GetMapping("/books/{id}")
-    public ResponseEntity<RetrieveBookResponse> retrieveBook (@PathVariable Long id) {
+    public ResponseEntity<RetrieveBookResponse> retrieveBook(@PathVariable Long id) {
         RetrieveBookResponse res = bookService.retrieveBook(id);
         return ResponseEntity
                 .status(HttpStatus.OK)
@@ -45,7 +64,7 @@ public class BookController {
     }
 
     @PatchMapping("/books/{id}")
-    public ResponseEntity<Void> updateBook (@PathVariable Long id, @Valid @RequestBody UpdateBookRequest req) {
+    public ResponseEntity<Void> updateBook(@PathVariable Long id, @Valid @RequestBody UpdateBookRequest req) {
         bookService.updateBook(id, req);
         return ResponseEntity
                 .ok()
@@ -53,7 +72,7 @@ public class BookController {
     }
 
     @DeleteMapping("/books/{id}")
-    public ResponseEntity<Void> deleteBook (@PathVariable Long id) {
+    public ResponseEntity<Void> deleteBook(@PathVariable Long id) {
         bookService.deleteBook(id);
         return ResponseEntity
                 .noContent()

--- a/src/main/java/com/hwk9407/bookmanagementassignment/api/book/dto/request/RetrieveAllBooksRequest.java
+++ b/src/main/java/com/hwk9407/bookmanagementassignment/api/book/dto/request/RetrieveAllBooksRequest.java
@@ -1,0 +1,29 @@
+package com.hwk9407.bookmanagementassignment.api.book.dto.request;
+
+import jakarta.validation.constraints.*;
+
+import java.time.LocalDate;
+
+public record RetrieveAllBooksRequest(
+
+        @Positive(message = "자연수만 입력할 수 있습니다")
+        Integer page,
+
+        @Min(1) @Max(50)
+        Integer size,
+
+        @Pattern(regexp = "ASC|DESC", message = "orderBy 필드는 ASC 또는 DESC 만 입력할 수 있습니다")
+        String orderBy,
+
+        @Pattern(regexp = "title|publicationDate", message = "sortBy 필드는 'title', 'publicationDate' 만 입력할 수 있습니다")
+        String sortBy,
+
+        Long authorId,
+
+        @PastOrPresent
+        LocalDate startPubDate,
+
+        @PastOrPresent
+        LocalDate endPubDate
+) {
+}

--- a/src/main/java/com/hwk9407/bookmanagementassignment/api/book/dto/request/UpdateBookRequest.java
+++ b/src/main/java/com/hwk9407/bookmanagementassignment/api/book/dto/request/UpdateBookRequest.java
@@ -9,7 +9,7 @@ import java.time.LocalDate;
 
 public record UpdateBookRequest(
 
-        @Pattern(regexp = "^(?!\\s*$).+", message = "빈 문자열이나 공백으로만 작성할 수 없습니다.")
+        @Pattern(regexp = "^(?!\\s*$).+", message = "빈 문자열이나 공백으로만 작성할 수 없습니다")
         String title,
 
         String description,

--- a/src/main/java/com/hwk9407/bookmanagementassignment/api/book/dto/response/RetrieveAllBooksResponse.java
+++ b/src/main/java/com/hwk9407/bookmanagementassignment/api/book/dto/response/RetrieveAllBooksResponse.java
@@ -1,18 +1,25 @@
 package com.hwk9407.bookmanagementassignment.api.book.dto.response;
 
 import com.hwk9407.bookmanagementassignment.domain.book.Book;
+import org.springframework.data.domain.Page;
 
 import java.util.List;
 
 public record RetrieveAllBooksResponse(
-        List<RetrieveBookResponse> contents
+        List<RetrieveBookResponse> contents,
+        int page,
+        int size,
+        int totalPage
 ) {
 
-    public static RetrieveAllBooksResponse from(List<Book> books) {
+    public static RetrieveAllBooksResponse from(Page<Book> books) {
         return new RetrieveAllBooksResponse(
-                books.stream()
+                books.getContent().stream()
                         .map(RetrieveBookResponse::from)
-                        .toList()
+                        .toList(),
+                books.getNumber() + 1,
+                books.getSize(),
+                books.getTotalPages()
         );
     }
 }

--- a/src/main/java/com/hwk9407/bookmanagementassignment/api/book/dto/response/RetrieveBookResponse.java
+++ b/src/main/java/com/hwk9407/bookmanagementassignment/api/book/dto/response/RetrieveBookResponse.java
@@ -5,6 +5,7 @@ import com.hwk9407.bookmanagementassignment.domain.book.Book;
 import java.time.LocalDate;
 
 public record RetrieveBookResponse(
+        Long id,
         String title,
         String description,
         String isbn,
@@ -15,6 +16,7 @@ public record RetrieveBookResponse(
 
     public static RetrieveBookResponse from(Book book) {
         return new RetrieveBookResponse(
+                book.getId(),
                 book.getTitle(),
                 book.getDescription(),
                 book.getIsbn(),

--- a/src/main/java/com/hwk9407/bookmanagementassignment/api/book/dto/response/RetrieveBookResponse.java
+++ b/src/main/java/com/hwk9407/bookmanagementassignment/api/book/dto/response/RetrieveBookResponse.java
@@ -9,7 +9,8 @@ public record RetrieveBookResponse(
         String description,
         String isbn,
         LocalDate publicationDate,
-        Long authorId
+        Long authorId,
+        String authorName
 ) {
 
     public static RetrieveBookResponse from(Book book) {
@@ -18,7 +19,8 @@ public record RetrieveBookResponse(
                 book.getDescription(),
                 book.getIsbn(),
                 book.getPublicationDate(),
-                book.getAuthor().getId()
+                book.getAuthor().getId(),
+                book.getAuthor().getName()
         );
     }
 }

--- a/src/main/java/com/hwk9407/bookmanagementassignment/api/book/service/BookService.java
+++ b/src/main/java/com/hwk9407/bookmanagementassignment/api/book/service/BookService.java
@@ -9,7 +9,7 @@ import com.hwk9407.bookmanagementassignment.domain.author.Author;
 import com.hwk9407.bookmanagementassignment.domain.author.AuthorRepository;
 import com.hwk9407.bookmanagementassignment.domain.book.Book;
 import com.hwk9407.bookmanagementassignment.domain.book.BookRepository;
-import com.hwk9407.bookmanagementassignment.domain.book.IsbnValidator;
+import com.hwk9407.bookmanagementassignment.api.book.validator.IsbnValidator;
 import com.hwk9407.bookmanagementassignment.exception.InvalidIsbnException;
 import jakarta.persistence.EntityNotFoundException;
 import jakarta.validation.Valid;

--- a/src/main/java/com/hwk9407/bookmanagementassignment/api/book/service/BookService.java
+++ b/src/main/java/com/hwk9407/bookmanagementassignment/api/book/service/BookService.java
@@ -47,7 +47,7 @@ public class BookService {
 
     @Transactional(readOnly = true)
     public RetrieveAllBooksResponse retrieveAllBooks() {
-        List<Book> books = bookRepository.findAll();
+        List<Book> books = bookRepository.findAllWithAuthors();
         return RetrieveAllBooksResponse.from(books);
     }
 

--- a/src/main/java/com/hwk9407/bookmanagementassignment/api/book/service/BookService.java
+++ b/src/main/java/com/hwk9407/bookmanagementassignment/api/book/service/BookService.java
@@ -1,6 +1,7 @@
 package com.hwk9407.bookmanagementassignment.api.book.service;
 
 import com.hwk9407.bookmanagementassignment.api.book.dto.request.AddBookRequest;
+import com.hwk9407.bookmanagementassignment.api.book.dto.request.RetrieveAllBooksRequest;
 import com.hwk9407.bookmanagementassignment.api.book.dto.request.UpdateBookRequest;
 import com.hwk9407.bookmanagementassignment.api.book.dto.response.AddBookResponse;
 import com.hwk9407.bookmanagementassignment.api.book.dto.response.RetrieveAllBooksResponse;
@@ -14,10 +15,12 @@ import com.hwk9407.bookmanagementassignment.exception.InvalidIsbnException;
 import jakarta.persistence.EntityNotFoundException;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-
-import java.util.List;
 
 @Service
 @RequiredArgsConstructor
@@ -46,8 +49,12 @@ public class BookService {
     }
 
     @Transactional(readOnly = true)
-    public RetrieveAllBooksResponse retrieveAllBooks() {
-        List<Book> books = bookRepository.findAllWithAuthors();
+    public RetrieveAllBooksResponse retrieveAllBooks(RetrieveAllBooksRequest req) {
+        Sort.Direction direction = "ASC".equalsIgnoreCase(req.orderBy()) ? Sort.Direction.ASC : Sort.Direction.DESC;
+        Sort sort = Sort.by(direction, req.sortBy());
+        Pageable pageable = PageRequest.of(req.page() - 1, req.size(), sort);
+        Page<Book> books = bookRepository.retrieveBooksWithFilter(req.authorId(), req.startPubDate(), req.endPubDate(), pageable);
+
         return RetrieveAllBooksResponse.from(books);
     }
 

--- a/src/main/java/com/hwk9407/bookmanagementassignment/api/book/service/BookService.java
+++ b/src/main/java/com/hwk9407/bookmanagementassignment/api/book/service/BookService.java
@@ -51,6 +51,7 @@ public class BookService {
         return RetrieveAllBooksResponse.from(books);
     }
 
+    @Transactional(readOnly = true)
     public RetrieveBookResponse retrieveBook(Long id) {
         Book book = bookRepository.findById(id).orElseThrow(
                 () -> new EntityNotFoundException("조회되지 않는 책 ID 입니다.")

--- a/src/main/java/com/hwk9407/bookmanagementassignment/api/book/validator/IsbnValidator.java
+++ b/src/main/java/com/hwk9407/bookmanagementassignment/api/book/validator/IsbnValidator.java
@@ -1,4 +1,4 @@
-package com.hwk9407.bookmanagementassignment.domain.book;
+package com.hwk9407.bookmanagementassignment.api.book.validator;
 
 import com.hwk9407.bookmanagementassignment.exception.InvalidIsbnException;
 import org.springframework.stereotype.Component;

--- a/src/main/java/com/hwk9407/bookmanagementassignment/config/JpaConfig.java
+++ b/src/main/java/com/hwk9407/bookmanagementassignment/config/JpaConfig.java
@@ -1,0 +1,19 @@
+package com.hwk9407.bookmanagementassignment.config;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class JpaConfig {
+
+    @PersistenceContext
+    private EntityManager em;
+
+    @Bean
+    public JPAQueryFactory jpaQueryFactory() {
+        return new JPAQueryFactory(em);
+    }
+}

--- a/src/main/java/com/hwk9407/bookmanagementassignment/domain/book/BookRepository.java
+++ b/src/main/java/com/hwk9407/bookmanagementassignment/domain/book/BookRepository.java
@@ -7,7 +7,7 @@ package com.hwk9407.bookmanagementassignment.domain.book;
 
  import java.util.List;
 
-public interface BookRepository extends JpaRepository<Book, Long> {
+public interface BookRepository extends JpaRepository<Book, Long>, BookRepositoryQuery {
 
     boolean existsByIsbn(String isbn);
 

--- a/src/main/java/com/hwk9407/bookmanagementassignment/domain/book/BookRepository.java
+++ b/src/main/java/com/hwk9407/bookmanagementassignment/domain/book/BookRepository.java
@@ -1,11 +1,19 @@
 package com.hwk9407.bookmanagementassignment.domain.book;
 
  import com.hwk9407.bookmanagementassignment.domain.author.Author;
-import org.springframework.data.jpa.repository.JpaRepository;
+ import org.springframework.data.jpa.repository.EntityGraph;
+ import org.springframework.data.jpa.repository.JpaRepository;
+ import org.springframework.data.jpa.repository.Query;
+
+ import java.util.List;
 
 public interface BookRepository extends JpaRepository<Book, Long> {
 
     boolean existsByIsbn(String isbn);
 
     boolean existsByAuthor(Author author);
+
+    @EntityGraph(attributePaths = {"author"})
+    @Query("SELECT b FROM Book b")
+    List<Book> findAllWithAuthors();
 }

--- a/src/main/java/com/hwk9407/bookmanagementassignment/domain/book/BookRepositoryQuery.java
+++ b/src/main/java/com/hwk9407/bookmanagementassignment/domain/book/BookRepositoryQuery.java
@@ -1,0 +1,11 @@
+package com.hwk9407.bookmanagementassignment.domain.book;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+import java.time.LocalDate;
+
+public interface BookRepositoryQuery {
+
+    Page<Book> retrieveBooksWithFilter(Long authorId, LocalDate startPubDate, LocalDate endPubDate, Pageable pageable);
+}

--- a/src/main/java/com/hwk9407/bookmanagementassignment/domain/book/BookRepositoryQueryImpl.java
+++ b/src/main/java/com/hwk9407/bookmanagementassignment/domain/book/BookRepositoryQueryImpl.java
@@ -15,7 +15,7 @@ import java.util.Optional;
 @RequiredArgsConstructor
 public class BookRepositoryQueryImpl implements BookRepositoryQuery {
 
-    private JPAQueryFactory queryFactory;
+    private final JPAQueryFactory queryFactory;
     QBook book = QBook.book;
 
     @Override

--- a/src/main/java/com/hwk9407/bookmanagementassignment/domain/book/BookRepositoryQueryImpl.java
+++ b/src/main/java/com/hwk9407/bookmanagementassignment/domain/book/BookRepositoryQueryImpl.java
@@ -1,12 +1,16 @@
 package com.hwk9407.bookmanagementassignment.domain.book;
 
+import com.hwk9407.bookmanagementassignment.domain.author.QAuthor;
 import com.querydsl.core.BooleanBuilder;
+import com.querydsl.core.types.OrderSpecifier;
+import com.querydsl.core.types.dsl.PathBuilder;
 import com.querydsl.jpa.impl.JPAQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 
 import java.time.LocalDate;
 import java.util.List;
@@ -17,6 +21,7 @@ public class BookRepositoryQueryImpl implements BookRepositoryQuery {
 
     private final JPAQueryFactory queryFactory;
     QBook book = QBook.book;
+    QAuthor author = QAuthor.author;
 
     @Override
     public Page<Book> retrieveBooksWithFilter(Long authorId, LocalDate startPubDate, LocalDate endPubDate, Pageable pageable) {
@@ -32,17 +37,31 @@ public class BookRepositoryQueryImpl implements BookRepositoryQuery {
             whereClause.and(book.publicationDate.loe(endPubDate));
         }
         JPAQuery<Book> query = queryFactory.selectFrom(book)
-                .fetchJoin()
-                .where(whereClause)
+                .join(book.author, author).fetchJoin()
+                .where(whereClause);
+        applyOrderBy(query, pageable)
                 .offset(pageable.getOffset())
                 .limit(pageable.getPageSize());
         List<Book> books = query.fetch();
         Long total = Optional.ofNullable(
                 queryFactory.select(book.count())
-                .from(book)
-                .where(whereClause)
-                .fetchOne()
+                        .from(book)
+                        .where(whereClause)
+                        .fetchOne()
         ).orElse(0L);
         return new PageImpl<>(books, pageable, total);
+    }
+
+    private JPAQuery<Book> applyOrderBy(JPAQuery<Book> query, Pageable pageable) {
+        if (pageable.getSort().isSorted()) {
+            for (Sort.Order order : pageable.getSort()) {
+                PathBuilder<Book> path = new PathBuilder<>(Book.class, "book");
+                OrderSpecifier<?> orderSpecifier = order.isAscending()
+                        ? path.getString(order.getProperty()).asc()
+                        : path.getString(order.getProperty()).desc();
+                query.orderBy(orderSpecifier);
+            }
+        }
+        return query;
     }
 }

--- a/src/main/java/com/hwk9407/bookmanagementassignment/domain/book/BookRepositoryQueryImpl.java
+++ b/src/main/java/com/hwk9407/bookmanagementassignment/domain/book/BookRepositoryQueryImpl.java
@@ -1,0 +1,48 @@
+package com.hwk9407.bookmanagementassignment.domain.book;
+
+import com.querydsl.core.BooleanBuilder;
+import com.querydsl.jpa.impl.JPAQuery;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Optional;
+
+@RequiredArgsConstructor
+public class BookRepositoryQueryImpl implements BookRepositoryQuery {
+
+    private JPAQueryFactory queryFactory;
+    QBook book = QBook.book;
+
+    @Override
+    public Page<Book> retrieveBooksWithFilter(Long authorId, LocalDate startPubDate, LocalDate endPubDate, Pageable pageable) {
+
+        BooleanBuilder whereClause = new BooleanBuilder();
+        if (authorId != null) {
+            whereClause.and(book.author.id.eq(authorId));
+        }
+        if (startPubDate != null) {
+            whereClause.and(book.publicationDate.goe(startPubDate));
+        }
+        if (endPubDate != null) {
+            whereClause.and(book.publicationDate.loe(endPubDate));
+        }
+        JPAQuery<Book> query = queryFactory.selectFrom(book)
+                .fetchJoin()
+                .where(whereClause)
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize());
+        List<Book> books = query.fetch();
+        Long total = Optional.ofNullable(
+                queryFactory.select(book.count())
+                .from(book)
+                .where(whereClause)
+                .fetchOne()
+        ).orElse(0L);
+        return new PageImpl<>(books, pageable, total);
+    }
+}

--- a/src/main/java/com/hwk9407/bookmanagementassignment/util/DtoValidator.java
+++ b/src/main/java/com/hwk9407/bookmanagementassignment/util/DtoValidator.java
@@ -1,0 +1,27 @@
+package com.hwk9407.bookmanagementassignment.util;
+
+import jakarta.validation.ConstraintViolation;
+import jakarta.validation.Validator;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+import java.util.Set;
+
+@RequiredArgsConstructor
+@Component
+public class DtoValidator {
+
+    private final Validator validator;
+
+    public <T> void validate(T dto) {
+        Set<ConstraintViolation<T>> violations = validator.validate(dto);
+        if (!violations.isEmpty()) {
+            List<String> errorMessages = violations.stream()
+                    .map(violation -> violation.getPropertyPath() + " 필드는 " + violation.getMessage())
+                    .toList();
+            String formattedMessage = String.join(", ", errorMessages);
+            throw new IllegalArgumentException(formattedMessage);
+        }
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,6 +1,6 @@
 spring:
   datasource:
-    url: jdbc:h2:file:./data/book_db
+    url: jdbc:h2:file:./data/book_db;AUTO_SERVER=TRUE
     driver-class-name: org.h2.Driver
     username: sa
     password:

--- a/src/test/java/com/hwk9407/bookmanagementassignment/domain/book/IsbnValidatorTest.java
+++ b/src/test/java/com/hwk9407/bookmanagementassignment/domain/book/IsbnValidatorTest.java
@@ -1,5 +1,6 @@
 package com.hwk9407.bookmanagementassignment.domain.book;
 
+import com.hwk9407.bookmanagementassignment.api.book.validator.IsbnValidator;
 import com.hwk9407.bookmanagementassignment.exception.InvalidIsbnException;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;


### PR DESCRIPTION
## 작업 상세 내용
- 페이지네이션 추가
  - [x] 도서 목록 조회 (`GET /books`)
    - [x] QueryDSL로 동적조건 및 동적정렬 구현 (저자 목록 조회는 정렬 컬럼이 많지 않아 Spring Data JPA로 페이지네이션 구현)
  - [x] 저자 목록 조회 (`GET /authors`)
  - [x] 도서 & 저자 목록 조회 시 Response Body에 `page`, `size`, `totalPage` 필드 추가
- [x] 도서 및 저자 조회 시 id 필드 추가
- 버그 수정 및 리팩토링
  - [x] 도서 상세 조회 시 트랜잭션 어노테이션 빠진 것 추가
  - [x] 도서 조회 Response Body에 저자 이름 필드도 조회될 수 있도록 수정
  - [x] 페이지네이션 적용 전 `@EntityGraph`를 통해서 N+1 문제가 해결
  - [x] validator 클래스 패키지 위치 변경
  - [x] 빠뜨린 도서 상세 조회 메서드에 트랜잭션 추가 (조회용 트랜잭션 명시)
  - [x] Dto 에 빠뜨린 검증 추가 및 예외 문자열 끝에 온점 제거


## 이슈 링크
- #8 