### PR TITLE
Test/author book crud/10

### DIFF
--- a/src/main/java/com/hwk9407/bookmanagementassignment/api/author/service/AuthorService.java
+++ b/src/main/java/com/hwk9407/bookmanagementassignment/api/author/service/AuthorService.java
@@ -17,11 +17,8 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
-import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-
-import java.util.List;
 
 @Service
 @RequiredArgsConstructor

--- a/src/main/java/com/hwk9407/bookmanagementassignment/domain/author/Author.java
+++ b/src/main/java/com/hwk9407/bookmanagementassignment/domain/author/Author.java
@@ -29,7 +29,7 @@ public class Author {
     }
 
     public void update(String name, String email) {
-        this.name = Objects.requireNonNull(name, this.name);
-        this.email = Objects.requireNonNull(email, this.email);
+        this.name = Objects.requireNonNullElse(name, this.name);
+        this.email = Objects.requireNonNullElse(email, this.email);
     }
 }

--- a/src/test/java/com/hwk9407/bookmanagementassignment/api/author/service/AuthorServiceIntegrationTest.java
+++ b/src/test/java/com/hwk9407/bookmanagementassignment/api/author/service/AuthorServiceIntegrationTest.java
@@ -1,0 +1,132 @@
+package com.hwk9407.bookmanagementassignment.api.author.service;
+
+import com.hwk9407.bookmanagementassignment.api.author.dto.request.RetrieveAllAuthorsRequest;
+import com.hwk9407.bookmanagementassignment.api.author.dto.request.UpdateAuthorRequest;
+import com.hwk9407.bookmanagementassignment.api.author.dto.response.RetrieveAllAuthorsResponse;
+import com.hwk9407.bookmanagementassignment.config.JpaConfig;
+import com.hwk9407.bookmanagementassignment.domain.author.Author;
+import com.hwk9407.bookmanagementassignment.domain.author.AuthorRepository;
+import com.hwk9407.bookmanagementassignment.domain.book.Book;
+import com.hwk9407.bookmanagementassignment.domain.book.BookRepository;
+import com.hwk9407.bookmanagementassignment.exception.CannotDeleteAuthorException;
+import com.hwk9407.bookmanagementassignment.exception.EmailAlreadyExistsException;
+import jakarta.persistence.EntityNotFoundException;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+
+import static org.assertj.core.api.Assertions.*;
+
+@DataJpaTest
+@Import({AuthorService.class, JpaConfig.class})
+class AuthorServiceIntegrationTest {
+
+    @Autowired
+    private AuthorService authorService;
+
+    @Autowired
+    private AuthorRepository authorRepository;
+
+    @Autowired
+    private BookRepository bookRepository;
+
+    private Author savedAuthor;
+
+    @BeforeEach
+    void setUp() {
+        savedAuthor = authorRepository.save(Author.builder()
+                .name("테스트 저자 001")
+                .email("test001@example.com")
+                .build()
+        );
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 ID 조회 시 EntityNotFoundException 발생")
+    public void nonExistentAuthorExceptionTest() {
+        // given
+        Long nonExistentId = 999L;
+
+        // when & then
+        assertThatThrownBy(() -> authorService.retrieveAuthor(nonExistentId))
+                .isInstanceOf(EntityNotFoundException.class)
+                .hasMessageContaining("조회되지 않는 저자 ID 입니다.");
+    }
+
+    @Test
+    @DisplayName("올바른 값이 잘 들어와서 페이지네이션이 잘 작동하는지 테스트")
+    public void paginationSuccessTest() {
+        // given
+        for (int i = 1; i <= 15; i++) {
+            authorRepository.save(Author.builder()
+                    .name("저자" + i)
+                    .email("author" + i + "@example.com")
+                    .build());
+        }
+        RetrieveAllAuthorsRequest req = new RetrieveAllAuthorsRequest(2, 10);
+
+        // when
+        RetrieveAllAuthorsResponse res = authorService.retrieveAllAuthors(req);
+
+        // then
+        assertThat(res.contents()).hasSize(6);
+        assertThat(res.totalPage()).isEqualTo(2);
+    }
+
+    @Test
+    @DisplayName("이메일 변경 시 이미 존재하는 이메일이면 EmailAlreadyExistsException 예외 발생")
+    public void updateAuthorDuplicateEmailExceptionTest1() {
+        // given
+        authorRepository.save(Author.builder()
+                .name("다른 저자")
+                .email("duplicate@example.com")
+                .build());
+        UpdateAuthorRequest req = new UpdateAuthorRequest(null, "duplicate@example.com");
+
+        // when & then
+        assertThatThrownBy(() -> authorService.updateAuthor(savedAuthor.getId(), req))
+                .isInstanceOf(EmailAlreadyExistsException.class)
+                .hasMessageContaining("이미 존재하는 이메일입니다.");
+    }
+
+    @Test
+    @DisplayName("본인의 이메일로 수정하는 경우 정상 작동 테스트")
+    public void updateAuthorDuplicateEmailExceptionTest2() {
+        // given
+        UpdateAuthorRequest req = new UpdateAuthorRequest(null, "test@example.com");
+
+        // when & then
+        assertThatCode(() -> authorService.updateAuthor(savedAuthor.getId(), req))
+                .doesNotThrowAnyException();
+    }
+
+    @Test
+    @DisplayName("삭제 시 연관된 책이 있으면 삭제 불가능 CannotDeleteAuthorException 예외 발생")
+    public void deleteAuthorExceptionTest() {
+        // given
+        bookRepository.save(Book.builder()
+                .title("테스트 도서")
+                .isbn("1234567890")
+                .author(savedAuthor)
+                .build());
+
+        // when & then
+        assertThatThrownBy(() -> authorService.deleteAuthor(savedAuthor.getId()))
+                .isInstanceOf(CannotDeleteAuthorException.class)
+                .hasMessageContaining("연관된 책이 존재하여 저자를 삭제할 수 없습니다.");
+    }
+
+    @Test
+    @DisplayName("연관 도서가 없는 저자는 정상 삭제됨")
+    public void deleteAuthorWithoutBooksShouldSucceed() {
+        // when
+        authorService.deleteAuthor(savedAuthor.getId());
+
+        // then
+        assertThat(authorRepository.existsById(savedAuthor.getId())).isFalse();
+    }
+}

--- a/src/test/java/com/hwk9407/bookmanagementassignment/api/book/service/BookServiceIntegrationTest.java
+++ b/src/test/java/com/hwk9407/bookmanagementassignment/api/book/service/BookServiceIntegrationTest.java
@@ -1,0 +1,150 @@
+package com.hwk9407.bookmanagementassignment.api.book.service;
+
+import com.hwk9407.bookmanagementassignment.api.book.dto.request.AddBookRequest;
+import com.hwk9407.bookmanagementassignment.api.book.dto.request.RetrieveAllBooksRequest;
+import com.hwk9407.bookmanagementassignment.api.book.dto.request.UpdateBookRequest;
+import com.hwk9407.bookmanagementassignment.api.book.dto.response.RetrieveAllBooksResponse;
+import com.hwk9407.bookmanagementassignment.api.book.validator.IsbnValidator;
+import com.hwk9407.bookmanagementassignment.config.JpaConfig;
+import com.hwk9407.bookmanagementassignment.domain.author.Author;
+import com.hwk9407.bookmanagementassignment.domain.author.AuthorRepository;
+import com.hwk9407.bookmanagementassignment.domain.book.Book;
+import com.hwk9407.bookmanagementassignment.domain.book.BookRepository;
+import com.hwk9407.bookmanagementassignment.exception.InvalidIsbnException;
+import jakarta.persistence.EntityNotFoundException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+
+import java.time.LocalDate;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doNothing;
+
+@DataJpaTest
+@Import({BookService.class, JpaConfig.class})
+class BookServiceIntegrationTest {
+
+    @Autowired
+    private BookService bookService;
+
+    @Autowired
+    private BookRepository bookRepository;
+
+    @Autowired
+    private AuthorRepository authorRepository;
+
+    // @MockBean 은 Spring boot 3.4.0 에서 Deprecated 됨!
+    @MockitoBean
+    private IsbnValidator isbnValidator;
+
+    private Author savedAuthor;
+    private Book savedBook;
+
+    @BeforeEach
+    void setUp() {
+        savedAuthor = authorRepository.save(Author.builder()
+                .name("테스트 저자 001")
+                .email("test001@example.com")
+                .build()
+        );
+        savedBook = bookRepository.save(Book.builder()
+                .title("테스트 도서 001")
+                .isbn("1234567890")
+                .author(savedAuthor)
+                .publicationDate(LocalDate.of(2025, 2, 25))
+                .build()
+        );
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 책 조회 시 EntityNotFoundException 예외 발생")
+    public void retrieveNonExistentBookExceptionTest() {
+        // given
+        Long nonExistentBookId = 999L;
+
+        // when & then
+        assertThatThrownBy(() -> bookService.retrieveBook(nonExistentBookId))
+                .isInstanceOf(EntityNotFoundException.class)
+                .hasMessageContaining("조회되지 않는 책 ID 입니다.");
+    }
+
+    @Test
+    @DisplayName("올바른 값이 들어와서 페이지네이션과 필터링, 정렬이 정상적으로 작동하는지 테스트")
+    public void paginationSuccessTest() {
+        // given
+        for (int i = 1; i <= 15; i++) {
+            bookRepository.save(Book.builder()
+                    .title("테스트 도서 " + i)
+                    .isbn("1234567890" + i)
+                    .author(savedAuthor)
+                    .publicationDate(LocalDate.of(2025, 1, i))
+                    .build());
+        }
+        RetrieveAllBooksRequest req = new RetrieveAllBooksRequest(2, 5, "ASC", "title", null, LocalDate.of(2025, 1, 2), LocalDate.of(2025, 1, 9));
+
+        // when
+        RetrieveAllBooksResponse res = bookService.retrieveAllBooks(req);
+
+        // then
+        assertThat(res.contents()).hasSize(3);
+        assertThat(res.totalPage()).isEqualTo(2);
+        assertThat(res.contents().get(0).title()).isEqualTo("테스트 도서 7");
+        assertThat(res.contents().get(1).title()).isEqualTo("테스트 도서 8");
+        assertThat(res.contents().get(2).title()).isEqualTo("테스트 도서 9");
+    }
+
+    @Test
+    @DisplayName("중복된 ISBN으로 도서를 추가하면 InvalidIsbnException 예외 발생")
+    public void addBookDuplicateIsbnExceptionTest() {
+        // given
+        AddBookRequest req = new AddBookRequest(
+                "새로운 도서",
+                "설명",
+                "1234567890",
+                null,
+                savedAuthor.getId()
+        );
+        doNothing().when(isbnValidator).validate(anyString());
+
+        // when & then
+        assertThatThrownBy(() -> bookService.addBook(req))
+                .isInstanceOf(InvalidIsbnException.class)
+                .hasMessageContaining("Isbn이 이미 존재합니다.");
+    }
+
+    @Test
+    @DisplayName("도서 수정 시 존재하지 않는 저자 ID로 변경하면 EntityNotFoundException 예외 발생")
+    public void updateBookNonExistentAuthorExceptionTest() {
+        // given
+        UpdateBookRequest req = new UpdateBookRequest(
+                "수정된 제목",
+                "수정된 설명",
+                "1111111110",
+                null,
+                999L
+        );
+        doNothing().when(isbnValidator).validate(anyString());
+
+        // when & then
+        assertThatThrownBy(() -> bookService.updateBook(savedBook.getId(), req))
+                .isInstanceOf(EntityNotFoundException.class)
+                .hasMessageContaining("존재하지 않는 저자 ID 입니다.");
+    }
+
+    @Test
+    @DisplayName("도서 삭제 시 정상적으로 삭제됨")
+    public void deleteBookSuccessTest() {
+        // when
+        bookService.deleteBook(savedBook.getId());
+
+        // then
+        assertThat(bookRepository.existsById(savedBook.getId())).isFalse();
+    }
+}

--- a/src/test/java/com/hwk9407/bookmanagementassignment/api/book/validator/IsbnValidatorTest.java
+++ b/src/test/java/com/hwk9407/bookmanagementassignment/api/book/validator/IsbnValidatorTest.java
@@ -1,6 +1,5 @@
-package com.hwk9407.bookmanagementassignment.domain.book;
+package com.hwk9407.bookmanagementassignment.api.book.validator;
 
-import com.hwk9407.bookmanagementassignment.api.book.validator.IsbnValidator;
 import com.hwk9407.bookmanagementassignment.exception.InvalidIsbnException;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;

--- a/src/test/java/com/hwk9407/bookmanagementassignment/util/DtoValidatorTest.java
+++ b/src/test/java/com/hwk9407/bookmanagementassignment/util/DtoValidatorTest.java
@@ -1,0 +1,53 @@
+package com.hwk9407.bookmanagementassignment.util;
+
+import com.hwk9407.bookmanagementassignment.api.author.dto.request.RetrieveAllAuthorsRequest;
+import jakarta.validation.ConstraintViolation;
+import jakarta.validation.Validator;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class DtoValidatorTest {
+
+    @Mock
+    private Validator validator;
+
+    @InjectMocks
+    private DtoValidator dtoValidator;
+
+    @Test
+    @DisplayName("유효한 DTO가 주어지면 예외없이 성공 테스트")
+    void passValidationSuccessTest() {
+        // given
+        RetrieveAllAuthorsRequest req = new RetrieveAllAuthorsRequest(1, 10);
+        when(validator.validate(req)).thenReturn(Set.of());
+
+        // when & then
+        Assertions.assertThatCode(() -> dtoValidator.validate(req))
+                .doesNotThrowAnyException();
+    }
+
+    @Test
+    @DisplayName("유효하지 않은 DTO가 주어지면 IllegalArgumentException 발생 테스트")
+    void throwExceptionWhenInvalidDtoGiven() {
+        // given
+        RetrieveAllAuthorsRequest invalidReq = new RetrieveAllAuthorsRequest(0, 100); // 유효하지 않은 값
+        ConstraintViolation<RetrieveAllAuthorsRequest> violation = mock(ConstraintViolation.class);
+        when(validator.validate(invalidReq)).thenReturn(Set.of(violation));
+
+        // when & then
+        assertThatThrownBy(() -> dtoValidator.validate(invalidReq))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+}

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -1,0 +1,11 @@
+# H2 메모리 데이터베이스 설정
+spring:
+  datasource:
+    url: jdbc:h2:mem:testdb
+    driver-class-name: org.h2.Driver
+    username: sa
+    password:
+  jpa:
+    hibernate:
+      ddl-auto: create-drop
+    database-platform: org.hibernate.dialect.H2Dialect


### PR DESCRIPTION
## 작업 상세 내용
### 도서 서비스 통합 테스트 주요 시나리오
- [x] 존재하지 않는 책 조회 시 `EntityNotFoundException` 예외 발생
- [x] 페이지네이션 및 필터링, 정렬 기능이 정상 동작하는지 테스트
- [x] 중복된 ISBN으로 도서를 추가하면 `InvalidIsbnException` 예외 발생
- [x] 존재하지 않는 저자 ID로 도서를 수정 시 `EntityNotFoundException` 예외 발생
- [x] 도서 삭제 시 정상적으로 삭제되는지 검증

### 저자 서비스 통합 테스트 주요 시나리오
- [x] 존재하지 않는 저자 조회 시 `EntityNotFoundException` 예외 발생
- [x] 페이지네이션이 정상적으로 작동하는지 테스트
- [x] 이메일 변경 시 중복 이메일이면 `EmailAlreadyExistsException` 예외 발생
- [x] 본인의 이메일로 수정하는 경우 정상적으로 수행됨
- [x] 연관된 책이 있는 경우 저자 삭제 불가능 (`CannotDeleteAuthorException`)
- [x] 연관된 책이 없는 경우 저자 삭제가 정상적으로 수행됨

### 기타
- [x] DtoValidator 단위 테스트 추가
- [x] 테스트용 application.yml 설정 파일 추가
- [x] 저자 엔티티의 update 메서드의 버그 수정 (`requireNonNull` → `requireNonNullElse`)
- [x] IsbnValidatorTest 테스트 패키지 이동

## 이슈 링크
- #10 