### PR TITLE
Docker 환경 구성 추가

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,5 @@
+FROM eclipse-temurin:17
+WORKDIR /app
+COPY build/libs/*.jar app.jar
+RUN mkdir -p /app/data
+CMD ["java", "-jar", "app.jar"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,9 @@
+services:
+  app:
+    container_name: book-management-container
+    build: .
+    ports:
+      - "8080:8080"
+    volumes:
+      - ./data:/app/data
+    restart: always

--- a/src/main/java/com/hwk9407/bookmanagementassignment/api/author/controller/AuthorController.java
+++ b/src/main/java/com/hwk9407/bookmanagementassignment/api/author/controller/AuthorController.java
@@ -85,7 +85,8 @@ public class AuthorController {
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "수정 성공"),
             @ApiResponse(responseCode = "400", description = "잘못된 요청"),
-            @ApiResponse(responseCode = "404", description = "존재하지 않는 저자")
+            @ApiResponse(responseCode = "404", description = "존재하지 않는 저자"),
+            @ApiResponse(responseCode = "409", description = "중복된 이메일로 인한 충돌")
     })
     @PatchMapping("/authors/{id}")
     public ResponseEntity<Void> updateAuthor (

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,6 +1,6 @@
 spring:
   datasource:
-    url: jdbc:h2:file:./data/book_db;AUTO_SERVER=TRUE
+    url: jdbc:h2:file:/app/data/book_db;AUTO_SERVER=TRUE
     driver-class-name: org.h2.Driver
     username: sa
     password:


### PR DESCRIPTION
## 작업 상세 내용
- [x] application.yml 에서 h2 db 경로를 절대경로로 변경 (`./data/book_db`→`/app/data/book_db`)
- [x] Dockerfile 추가 → JDK 환경 설정 및 애플리케이션 실행 가능하도록 구성
  - Eclipse Temurin 17 JDK 사용
  - 빌드된 jar 파일 /app 디렉토리로 복사
  - H2 DB 파일 저장을 위한 /app/data 폴더 생성
  - 어플리케이션 실행을 위한 CMD 명령어 수행
- [x] docker-compose.yml 추가
  - 컨테이너 이름으로 book-management-container 사용
  - 같은 프로젝트 루트 디렉토리에 있는 Dockerfile을 기반으로 빌드 수행 
  - 호스트와 컨테이너 포트 8080:8080 매핑
  - H2 DB 파일 유지를 위한 볼륨 마운트 (.data:/app/data)
  - 컨테이너 자동 재시작 설정

## 기타
- [x] 저자 정보 수정API에 Swagger 문서에 빠뜨린 409 예외코드 추가

## 앞으로의 과제
- [x] 실행 방법을 README에 추가할 것

## 이슈 링크
- #9 